### PR TITLE
Set default gas limit in truffle.js

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -3,6 +3,7 @@ module.exports = {
     development: {
       host: "localhost",
       port: 8545,
+      gas: 500000,
       network_id: "*" // Match any network id
     }
   }


### PR DESCRIPTION
Hello. 

I was following the tutorial out of the box, and ran up to `truffle compile` successfully.
But when running `truffle migrate`, I hit this error.

```bash
$ truffle migrate
Using network 'development'.

Running migration: 1_initial_migration.js
  Deploying Migrations...
  ... undefined
Error encountered, bailing. Network state unknown. Review successful transactions manually.
Error: Error: Exceeds block gas limit
```

After adding a default `gas` to `truffle.js`, I was able to successfully deploy to `testrpc`

```
$ truffle migrate
Using network 'development'.

Running migration: 1_initial_migration.js
  Deploying Migrations...
  ... 0x9da43a8a8dfad75b28b4719df55e345bf1b96ad151b52e967a29ff9326c48ef8
  Migrations: 0xf9957590e972281ebd74ecbfc83d35fe1cfe9fb8
Saving successful migration to network...
  ... 0xe2559c2192ec1aeaa075e5b50ab7b5a962f2f8a76519a72cd83b760c03c7d1e0
```

This might be a good idea to add into the default truffle box here so folks going through the [installation docs](http://truffleframework.com/boxes/truffle-vue) won't hit the same error. 